### PR TITLE
Add the option of hiding the website list

### DIFF
--- a/src/main/java/com/acunetix/ConfigManager.java
+++ b/src/main/java/com/acunetix/ConfigManager.java
@@ -4,6 +4,7 @@ import com.atlassian.bamboo.bandana.PlanAwareBandanaContext;
 import com.atlassian.bandana.BandanaManager;
 import com.atlassian.spring.container.ContainerManager;
 import com.acunetix.model.ScanRequestBase;
+import com.acunetix.model.TaskDialogProperties;
 import com.acunetix.utility.AppCommon;
 
 
@@ -28,6 +29,10 @@ public class ConfigManager {
 
 	public String getApiToken() {
 		return get(ScanRequestBase.API_TOKEN_Literal);
+	}
+
+	public String getHideWebsiteList() {
+		return get(TaskDialogProperties.HIDE_WEBSITE_LIST_Literal);
 	}
 
 	public String getScanTaskID(String planKey, String buildNumber) {

--- a/src/main/java/com/acunetix/PluginSettings.java
+++ b/src/main/java/com/acunetix/PluginSettings.java
@@ -9,6 +9,7 @@ import com.atlassian.bamboo.ww2.aware.permissions.GlobalAdminSecurityAware;
 import com.atlassian.bandana.BandanaManager;
 import com.atlassian.sal.api.component.ComponentLocator;
 import com.acunetix.model.ScanRequestBase;
+import com.acunetix.model.TaskDialogProperties;
 import com.acunetix.utility.AppCommon;
 
 
@@ -16,6 +17,7 @@ public class PluginSettings extends BambooActionSupport implements GlobalAdminSe
 
 	private String apiUrl;
 	private String apiToken;
+	private String hideWebsiteList;
 	private BandanaManager bandanaManager;
 
 	public PluginSettings() {
@@ -44,11 +46,18 @@ public class PluginSettings extends BambooActionSupport implements GlobalAdminSe
 		this.apiToken = apiToken;
 	}
 
+	public String getHideWebsiteList() {
+		return hideWebsiteList;
+	}
+
+	public void setHideWebsiteList(String hideWebsiteList) {
+		this.hideWebsiteList = hideWebsiteList;
+	}
 
 	public String doEdit() {
 		setApiUrl(getValue(ScanRequestBase.API_URL_Literal));
 		setApiToken(getValue(ScanRequestBase.API_TOKEN_Literal));
-
+		setHideWebsiteList(getValue(TaskDialogProperties.HIDE_WEBSITE_LIST_Literal));
 		return INPUT;
 	}
 
@@ -69,6 +78,7 @@ public class PluginSettings extends BambooActionSupport implements GlobalAdminSe
 		bandanaManager.init();
 		setValue(ScanRequestBase.API_URL_Literal, getApiUrl());
 		setValue(ScanRequestBase.API_TOKEN_Literal, getApiToken());
+		setValue(TaskDialogProperties.HIDE_WEBSITE_LIST_Literal, getHideWebsiteList());
 		addActionMessage("Global settings updated.");
 
 		return SUCCESS;

--- a/src/main/java/com/acunetix/model/TaskDialogProperties.java
+++ b/src/main/java/com/acunetix/model/TaskDialogProperties.java
@@ -1,0 +1,16 @@
+package com.acunetix.model;
+
+public class TaskDialogProperties {
+
+    public static final String HIDE_WEBSITE_LIST_Literal = "acunetix360HideWebsiteList";
+    public final String HideWebsiteList;
+
+    public TaskDialogProperties(String hideWebsiteList) {
+        this.HideWebsiteList = hideWebsiteList;
+    }
+
+    public TaskDialogProperties() {
+        this.HideWebsiteList = null;
+    }
+
+}

--- a/src/main/java/com/acunetix/tasks/Acunetix360ScanTaskConfigurator.java
+++ b/src/main/java/com/acunetix/tasks/Acunetix360ScanTaskConfigurator.java
@@ -2,6 +2,7 @@ package com.acunetix.tasks;
 
 import com.acunetix.ConfigManager;
 import com.acunetix.model.ScanRequest;
+import com.acunetix.model.TaskDialogProperties;
 import com.acunetix.model.ScanType;
 import com.acunetix.model.WebsiteModelRequest;
 import com.acunetix.utility.AppCommon;
@@ -68,6 +69,7 @@ public class Acunetix360ScanTaskConfigurator extends AbstractTaskConfigurator {
                 context.put(WebsiteModelRequest.ERROR_MESSAGE_Literal, errorMessage);
             } else {
                 context.put(WebsiteModelRequest.Websites_JSON_MODEL_Literal, websitesJsonModel);
+                context.put(TaskDialogProperties.HIDE_WEBSITE_LIST_Literal, configManager.getHideWebsiteList());
             }
         }
     }
@@ -119,6 +121,7 @@ public class Acunetix360ScanTaskConfigurator extends AbstractTaskConfigurator {
         config.put(ScanRequest.SCAN_TYPE_Literal, params.getString(ScanRequest.SCAN_TYPE_Literal));
         config.put(ScanRequest.WEBSITE_ID_Literal, params.getString(ScanRequest.WEBSITE_ID_Literal));
         config.put(ScanRequest.PROFILE_ID_Literal, params.getString(ScanRequest.PROFILE_ID_Literal));
+        config.put(TaskDialogProperties.HIDE_WEBSITE_LIST_Literal, params.getString(TaskDialogProperties.HIDE_WEBSITE_LIST_Literal));
 
         return config;
     }

--- a/src/main/resources/templates/PluginSettings.ftl
+++ b/src/main/resources/templates/PluginSettings.ftl
@@ -42,6 +42,8 @@ cancelUri='/admin/administer.action']
             </button>
             <div id="acunetix360TestConnectionButtonSpinner"
                  style="display: inline-block;margin: 5px;margin-left:10px;"></div>
+            <h2 style="margin-left: 55px;">Plugin Settings</h2>
+            [@ww.checkbox name='hideWebsiteList' toggle='true' label='Hide website list' description='In the task configuration dialog, replace the websites dropdown list with a simple text field to enter the Website ID.'/]
         </section>
     </div>
 </div>

--- a/src/main/resources/templates/task/Acunetix360ScanTaskEdit.ftl
+++ b/src/main/resources/templates/task/Acunetix360ScanTaskEdit.ftl
@@ -31,6 +31,22 @@
         Performs full scan with provided profile settings.
     </div>
 </div>
+
+[#if (acunetix360HideWebsiteList)??]
+<div class="field-group" style="display: none">
+    <label for="acunetix360WebsiteID">Website ID
+        <span class="aui-icon icon-required">(required)</span>
+    </label>
+    <input type="text" name="acunetix360WebsiteID" id="acunetix360WebsiteID"
+           value="${acunetix360WebsiteID!""}">
+    <span class="aui-icon icon-inline-help"><span>Help</span></span>
+    <div class="error">${acunetix360WebsiteIDErrorError!""}</div>
+    <div class="field-help description hidden">
+        Unique Id for your website on Acunetix 360, which will be scanned.<br>
+        Format should be like xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx.
+    </div>
+</div>
+[#else]
 <div class="field-group" style="display: none">
     <label for="acunetix360WebsiteID">Website Deploy URL
         <span class="aui-icon icon-required">(required)</span>
@@ -46,6 +62,8 @@
         This address will be scanned.
     </div>
 </div>
+[/#if]
+
 <div class="field-group" style="display: none">
     <label for="acunetix360ProfileID">Profile Name
         <span class="aui-icon icon-required">(required)</span>
@@ -133,11 +151,15 @@
     function updateNcParamsAndUI() {
         ncScanParams.scanType = ncScanTypeInput.val();
 
+        [#if (acunetix360HideWebsiteList)??]
+        ncScanParams.websiteId = ncWebsiteIdInput.val();
+        [#else]
         ncWebsiteIdInput.val(ncWebsiteIdDummySelect.val());
         ncScanParams.websiteId = ncWebsiteIdInput.val();
         if (!ncScanParams.websiteId) {
             ncProfileIdDummySelect.val("");
         }
+        [/#if]
 
         ncProfileIdInput.val(ncProfileIdDummySelect.val());
         ncScanParams.profileId = ncProfileIdInput.val();


### PR DESCRIPTION
In some cases, it is not relevant to display all websites in a dropdown list on the Task configuration page. 

This behavior is for example unsuitable when there is a large number of websites, or when you don't want a project team to be able to launch a scan on a website that doesn't concern them.

This change adds the possibility to configure the plugin to hide the website dropdown list, replacing it with a simple text field to enter the website ID.

A checkbox has been added in the plug-in configuration dialog:
![plugin-config](https://user-images.githubusercontent.com/34570583/195572588-00473fcb-8d14-4244-a1c8-1c53b57d675d.png)

When checked, the website dropdown list in the task configuration is replaced with a simple text field:
![task-edit](https://user-images.githubusercontent.com/34570583/195572586-afe512a9-cb4d-44d5-8465-2572f489207b.png)

